### PR TITLE
fix(SearchIndexRank): Set result rank by iteration index for fixed order, CLD-1487

### DIFF
--- a/com.cloudempiere.searchindex/src/com/cloudempiere/searchindex/indexprovider/pgtextsearch/PGTextSearchIndexProvider.java
+++ b/com.cloudempiere.searchindex/src/com/cloudempiere/searchindex/indexprovider/pgtextsearch/PGTextSearchIndexProvider.java
@@ -268,7 +268,6 @@ public class PGTextSearchIndexProvider implements ISearchIndexProvider {
             while (rs.next()) {
                 int AD_Table_ID = rs.getInt(1);
                 int recordID = rs.getInt(2);
-                double rank = rs.getDouble(3);
 
                 // FIXME: uncomment and discuss
 //                int AD_Window_ID = Env.getZoomWindowID(AD_Table_ID, recordID);
@@ -281,7 +280,7 @@ public class PGTextSearchIndexProvider implements ISearchIndexProvider {
                 result = new PGTextSearchResult();
                 result.setAD_Table_ID(AD_Table_ID);
                 result.setRecord_ID(recordID);
-                result.setRank(rank);
+                result.setRank(i); // set i instead of rank to get a fix order
                 results.add(result);
 
                 if (i < 10) {


### PR DESCRIPTION
Replaces the rank value from the result set with the iteration index when setting the rank in PGTextSearchResult. This change ensures a fixed order in the search results, possibly for debugging or consistent display purposes.