### PR TITLE
fix(SearchIdxEventHandler): Added record id check, CLD-1527

### DIFF
--- a/com.cloudempiere.searchindex/src/com/cloudempiere/searchindex/event/SearchIndexEventHandler.java
+++ b/com.cloudempiere.searchindex/src/com/cloudempiere/searchindex/event/SearchIndexEventHandler.java
@@ -278,7 +278,8 @@ public class SearchIndexEventHandler extends AbstractEventHandler {
 				if (po.columnExists(keyCol)) {
 					//  TODO apply where clause here too
 					int recordId = po.get_ValueAsInt(keyCol);
-					mainPOSet.add(new GenericPO(mainTableName, ctx, recordId, trxName));
+					if (recordId > 0)
+						mainPOSet.add(new GenericPO(mainTableName, ctx, recordId, trxName));
 				}
 			}
 		}


### PR DESCRIPTION
if the main record is not found (e.g. BPartner for a User), it created a PO with id 0, which means a new record - this was a bug that is fixed in this commit..