### PR TITLE
fix(build): resolve PDE warnings and unused code

### DIFF
--- a/com.cloudempiere.searchindex.ui/META-INF/MANIFEST.MF
+++ b/com.cloudempiere.searchindex.ui/META-INF/MANIFEST.MF
@@ -11,4 +11,3 @@ Require-Bundle: org.adempiere.plugin.utils;bundle-version="10.0.0",
 Export-Package: com.cloudempiere.searchindex.ui.dashboard
 Bundle-ClassPath: zul/,
  .
-Automatic-Module-Name: com.cloudempiere.searchindex.ui

--- a/com.cloudempiere.searchindex.ui/META-INF/MANIFEST.MF
+++ b/com.cloudempiere.searchindex.ui/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: SearchIndexUI
 Bundle-SymbolicName: com.cloudempiere.searchindex.ui
+Automatic-Module-Name: com.cloudempiere.searchindex.ui
 Bundle-Version: 10.2.0.qualifier
 Fragment-Host: org.adempiere.ui.zk
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/com.cloudempiere.searchindex.ui/build.properties
+++ b/com.cloudempiere.searchindex.ui/build.properties
@@ -1,5 +1,6 @@
 source.. = src/
 output.. = target/classes/
+output.zul/ = zul/
 bin.includes = META-INF/,\
                .,\
                zul/

--- a/com.cloudempiere.searchindex.ui/src/com/cloudempiere/searchindex/ui/ZkSearchIndexUI.java
+++ b/com.cloudempiere.searchindex.ui/src/com/cloudempiere/searchindex/ui/ZkSearchIndexUI.java
@@ -208,7 +208,7 @@ public class ZkSearchIndexUI extends Div implements EventListener<Event> {
 					end = results.size();
 
 //				TODO test and fix:
-//				for (int i = start; i < end; i++)
+//				for (int i = pgno * 10; i < end; i++)
 //					searchIndexProviderList.setHeadline(results.get(i), searchCombobox.getValue());
 
 				setModel(results);

--- a/com.cloudempiere.searchindex.ui/src/com/cloudempiere/searchindex/ui/ZkSearchIndexUI.java
+++ b/com.cloudempiere.searchindex.ui/src/com/cloudempiere/searchindex/ui/ZkSearchIndexUI.java
@@ -202,7 +202,6 @@ public class ZkSearchIndexUI extends Div implements EventListener<Event> {
 			int pgno = ee.getActivePage();
 
 			if (pgno != 0 && results != null) {
-				int start = pgno * 10;
 				int end = (pgno * 10) + 10;
 
 				if (end > results.size())

--- a/com.cloudempiere.searchindex/src/com/cloudempiere/searchindex/indexprovider/pgtextsearch/PGTextSearchIndexProvider.java
+++ b/com.cloudempiere.searchindex/src/com/cloudempiere/searchindex/indexprovider/pgtextsearch/PGTextSearchIndexProvider.java
@@ -363,13 +363,18 @@ public class PGTextSearchIndexProvider implements ISearchIndexProvider {
 		if (indexQuery.get(result.getAD_Table_ID()) != null) {
 			sql.append(indexQuery.get(result.getAD_Table_ID()));
 		} else {
-
-			ArrayList<Integer> columnIds = null;//getIndexedColumns(result.getAD_Table_ID()); // TODO
-
-			if(columnIds == null || columnIds.isEmpty()) {
-				result.setHtmlHeadline("");
-				return;
-			}
+			// TODO: re-enable when getIndexedColumns/getIndexSql are implemented
+			//ArrayList<Integer> columnIds = getIndexedColumns(result.getAD_Table_ID());
+			//if (columnIds != null && !columnIds.isEmpty()) {
+			//    sql.append("SELECT ts_headline(body, q) FROM (");
+			//    sql.append(getIndexSql(columnIds, result.getAD_Table_ID()));
+			//    indexQuery.put(result.getAD_Table_ID(), sql.toString());
+			//} else {
+			//    result.setHtmlHeadline("");
+			//    return;
+			//}
+			result.setHtmlHeadline("");
+			return;
 		}
 
 		//Bring the table ids that are indexed

--- a/com.cloudempiere.searchindex/src/com/cloudempiere/searchindex/indexprovider/pgtextsearch/PGTextSearchIndexProvider.java
+++ b/com.cloudempiere.searchindex/src/com/cloudempiere/searchindex/indexprovider/pgtextsearch/PGTextSearchIndexProvider.java
@@ -41,7 +41,6 @@ import java.util.logging.Level;
 
 import org.adempiere.util.IProcessUI;
 import org.compiere.model.MClient;
-import org.compiere.model.MRole;
 import org.compiere.util.DB;
 import org.compiere.util.Env;
 import org.compiere.util.Util;
@@ -296,7 +295,6 @@ public class PGTextSearchIndexProvider implements ISearchIndexProvider {
             }
         }
 
-        MRole role = MRole.getDefault(ctx, false);
         PreparedStatement pstmt = null;
         ResultSet rs = null;
         try {
@@ -372,11 +370,6 @@ public class PGTextSearchIndexProvider implements ISearchIndexProvider {
 				result.setHtmlHeadline("");
 				return;
 			}
-
-			sql.append("SELECT ts_headline(body, q) FROM (");			
-//			sql.append(getIndexSql(columnIds, result.getAD_Table_ID())); // TODO
-
-			indexQuery.put(result.getAD_Table_ID(), sql.toString());
 		}
 
 		//Bring the table ids that are indexed


### PR DESCRIPTION
- Fix output folder from bin/ to target/classes/ in both plugins
- Add Automatic-Module-Name to UI MANIFEST.MF
- Add output.zul/ mapping to resolve class folder association warning
- Remove unused variables (start, role) and dead code in setHeadline